### PR TITLE
Fix transposes

### DIFF
--- a/lofarantpos/geo.py
+++ b/lofarantpos/geo.py
@@ -54,12 +54,17 @@ def geographic_array_from_xyz(xyz_m):
         >>> geographic_array_from_xyz([xyz_m, xyz_m])
         array([[ 0.11168349,  0.92223593, -0.28265955],
                [ 0.11168349,  0.92223593, -0.28265955]])
+
+        >>> geographic_array_from_xyz([[xyz_m, xyz_m]]).shape
+        (1, 2, 3)
     """
     wgs84_a = 6378137.0
     wgs84_f = 1./298.257223563
     wgs84_e2 = wgs84_f*(2.0 - wgs84_f)
     
-    x_m, y_m, z_m = transpose(xyz_m)
+    x_m = array(xyz_m)[..., 0]
+    y_m = array(xyz_m)[..., 1]
+    z_m = array(xyz_m)[..., 2]
     lon_rad = arctan2(y_m, x_m)
     r_m = sqrt(x_m**2 + y_m**2)
     # Iterate to latitude solution
@@ -71,7 +76,7 @@ def geographic_array_from_xyz(xyz_m):
                       r_m)
     lat_rad = phi
     height_m = r_m*cos(lat_rad) + z_m*sin(lat_rad) - wgs84_a*sqrt(1.0 - wgs84_e2*sin(lat_rad)**2)
-    return vstack((lon_rad, lat_rad, height_m)).T
+    return stack([lon_rad, lat_rad, height_m], -1)
 
 
 def localnorth_to_etrs(centerxyz_m):

--- a/lofarantpos/geo.py
+++ b/lofarantpos/geo.py
@@ -140,8 +140,8 @@ def normal_vector_ellipsoid(lon_rad, lat_rad):
     Examples:
         >>> normal_vector_ellipsoid(0.12, 0.92)
         array([0.60146348, 0.07252407, 0.79560162])
-        >>> normal_vector_ellipsoid([0.12, 0.13], [0.92, 0.93]).shape
-        (2, 3)
+        >>> normal_vector_ellipsoid([[0.12, 0.13]], [[0.92, 0.93]]).shape
+        (1, 2, 3)
     """
     normalvector = array([cos(lat_rad) * cos(lon_rad),
                           cos(lat_rad) * sin(lon_rad),
@@ -186,8 +186,9 @@ def projection_matrix(xyz0_m, normal_vector):
         array([[ 0.04616828, -0.79966543,  0.59866826],
                [ 0.99117465,  0.11122275,  0.07212702],
                [-0.12426302,  0.59005482,  0.79774307]])
-        >>> projection_matrix([test_coord, test_coord], [cs002_normal, cs002_normal]).shape
-        (2, 3, 3)
+        >>> projection_matrix([[test_coord, test_coord]],
+        ...                   [[cs002_normal, cs002_normal]]).shape
+        (1, 2, 3, 3)
     """
     assert len(xyz0_m) == len(xyz0_m)
     r_unit = array(normal_vector)

--- a/lofarantpos/plotutil.py
+++ b/lofarantpos/plotutil.py
@@ -495,12 +495,12 @@ def add_background(ax, centre, background, zoom=18):
         geographic_array_from_xyz(
             centre + (localnorth_to_etrs(centre) @ [xmin, ymin, 0])
         )
-    )[0]
+    )
     xmax_deg, ymax_deg, _ = np.rad2deg(
         geographic_array_from_xyz(
             centre + (localnorth_to_etrs(centre) @ [xmax, ymax, 0])
         )
-    )[0]
+    )
 
     extent = tilemapbase.Extent.from_lonlat(xmin_deg, xmax_deg, ymin_deg, ymax_deg)
 


### PR DESCRIPTION
In various places, .T was used to index the last few variables. With input shapes of more than two dimensions, this caused swapping of the other dimensions.