### PR TITLE
Silence numpy2 warning, fix failing tests, and lack of integration of doctests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lofarantpos"
-version = "0.7.0"
+version = "0.7.1"
 description = "Access, query, and manipulate LOFAR antenna positions"
 authors = [
     {name = "Tammo Jan Dijkema", email = "dijkema@astron.nl"},
@@ -31,3 +31,6 @@ requires=[
 
 [project.urls]
 Homepage = "https://github.com/lofar-astron/lofar-antenna-positions"
+
+[tool.pytest.ini_options]
+addopts = "--doctest-modules --doctest-continue-on-failure --ignore=scripts --ignore=docs"

--- a/src/lofarantpos/db.py
+++ b/src/lofarantpos/db.py
@@ -3,17 +3,17 @@
 Module for manipulating LOFAR antenna databases. Typical usage is to create
 an instance of a LofarAntennaDatabase:
 
->>> import lofarantpos, numpy
+>>> import lofarantpos.db, numpy
 >>> db = lofarantpos.db.LofarAntennaDatabase()
 >>> db.phase_centres['CS001LBA']
 array([3826923.942,  460915.117, 5064643.229])
 >>> numpy.set_printoptions(suppress=True)
 >>> db.antenna_pqr('RS210LBA')[:5]
 array([[ 0.        ,  0.        ,  0.        ],
-       [-0.00006...,  2.55059...,  0.00185...],
-       [ 2.24997...,  1.3499502 ,  0.00130...],
-       [ 2.24982..., -1.35031..., -0.0004149 ],
-       [ 0.00006..., -2.55059..., -0.00185...]])
+       [-0.00006318,  2.55059612,  0.00185307],
+       [ 2.24997639,  1.3499502 ,  0.00130843],
+       [ 2.24982406, -1.35031535, -0.0004149 ],
+       [ 0.00006318, -2.55059612, -0.00185307]])
 >>> db.cabinet_etrs['CS002']
 array([3826609.602,  460990.583, 5064879.514])
 """
@@ -220,10 +220,10 @@ class LofarAntennaDatabase(object):
             >>> import numpy
             >>> db = lofarantpos.db.LofarAntennaDatabase()
             >>> db.hba_dipole_pqr("CS001HBA0")[:5]
-            array([[ 1.9336444 , 15.284...  ,  0.00008769],
+            array([[ 1.9336444 , 15.284537  ,  0.00008769],
                    [ 3.075576  , 14.776116  ,  0.00008769],
                    [ 4.217508  , 14.267695  ,  0.00008769],
-                   [ 5.3594... , 13.7592745 ,  0.00008769],
+                   [ 5.35944   , 13.7592745 ,  0.00008769],
                    [ 1.4252236 , 14.142605  ,  0.00008769]], dtype=float32)
         """
         base_tile = numpy.array([[[-1.5, 1.5], [-0.5, 1.5], [+0.5, 1.5], [+1.5, +1.5]],

--- a/src/lofarantpos/geo.py
+++ b/src/lofarantpos/geo.py
@@ -1,7 +1,7 @@
 """Functions for geographic transformations commonly used for LOFAR"""
 
 from numpy import sqrt, sin, cos, arctan2, array, cross, dot, float64, vstack, transpose, shape, concatenate, zeros_like, newaxis, stack, moveaxis, set_printoptions
-from numpy.linalg.linalg import norm
+from numpy.linalg import norm
 
 
 def normalized_earth_radius(latitude_rad):
@@ -21,19 +21,18 @@ def geographic_from_xyz(xyz_m):
         Dict[Union[array, float]: Dictionary with 'lon_rad', 'lat_rad', 'height_m',
                                      values are float for a single input, arrays for multiple inputs
 
-    Examples:
+    Example:
         >>> from pprint import pprint
         >>> xyz_m = [3836811, 430299, 5059823]
         >>> pprint(geographic_from_xyz(xyz_m))
         {'height_m': -0.28265954554080963,
-        ...'lat_rad': 0.9222359279580563,
-        ...'lon_rad': 0.11168348969295486}
-
+         'lat_rad': 0.9222359279580563,
+         'lon_rad': 0.11168348969295486}
         >>> xyz2_m = array([3828615, 438754, 5065265])
         >>> pprint(geographic_from_xyz([xyz_m, xyz2_m]))
         {'height_m': array([-0.28265955, -0.74483879]),
-        ...'lat_rad': array([0.92223593, 0.92365033]),
-        ...'lon_rad': array([0.11168349, 0.11410087])}
+         'lat_rad': array([0.92223593, 0.92365033]),
+         'lon_rad': array([0.11168349, 0.11410087])}
 
         >>> geographic_from_xyz([[xyz_m, xyz2_m]])['lon_rad'].shape
         (1, 2)

--- a/src/lofarantpos/plotutil.py
+++ b/src/lofarantpos/plotutil.py
@@ -1,8 +1,8 @@
 """
 Functions for plotting LOFAR stations with matplotlib
 """
-from .db import LofarAntennaDatabase
-from .geo import (
+from lofarantpos.db import LofarAntennaDatabase
+from lofarantpos.geo import (
     localnorth_to_etrs,
     geographic_array_from_xyz,
     xyz_from_geographic,


### PR DESCRIPTION
With the release of numpy 2.0, np.linalg.linalg has been depricated[0], and it's use in the module was raising warnings. This MR changes the linalg.norm import to use the parent linalg module to remove the warning.

Tests were broken, so I fixed them (and integrated the doctests into the pytest config) too.

[0] https://numpy.org/doc/stable/release/2.0.0-notes.html#numpy-linalg-linalg-made-private